### PR TITLE
Add .gitlab-ci.yml

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,30 @@
+.artifacts:
+  artifacts:
+    paths:
+      - public
+
+build:
+  extends: .artifacts
+  image: python:alpine
+  before_script:
+    - apk add py3-mako py3-yaml
+    - python -m venv --system-site-packages venv
+    - source venv/bin/activate
+    - python setup.py develop
+  script:
+    - ./asknot-ng.py templates/index.html questions/archlinux.yml
+      l10n/fedora/locale --theme archlinux
+  after_script:
+    - mv build/en public
+
+pages:
+  extends: .artifacts
+  stage: deploy
+  variables:
+    GIT_STRATEGY: none
+  image: alpine
+  script:
+    find public -type f -regex '.*\.\(css\|html\|jpg|js\|png\)' -exec
+    gzip -k {} +
+  only:
+    - archlinux


### PR DESCRIPTION
Our GitLab instance doesn't have Pages set up, so I'm using gitlab.com for hosting builds currently:
https://polyzen.gitlab.io/asknot-ng

Also enables demoing branches/merge requests, eg. [this build](https://gitlab.com/polyzen/asknot-ng/-/jobs/837122055) of @sonuishaq67's theme changes:
https://polyzen.gitlab.io/-/asknot-ng/-/jobs/837122055/artifacts/public/index.html